### PR TITLE
Remove universal TO_JSON:

### DIFF
--- a/lib/Dancer2/Session/JSON.pm
+++ b/lib/Dancer2/Session/JSON.pm
@@ -9,7 +9,7 @@ our $VERSION = '0.002';
 
 use Moo;
 use Dancer2::Core::Types;
-use JSON -convert_blessed_universally;
+use JSON;
 
 #--------------------------------------------------------------------------#
 # Attributes
@@ -44,7 +44,7 @@ with 'Dancer2::Core::Role::SessionFactory::File';
 sub _freeze_to_handle {
     my ( $self, $fh, $data ) = @_;
     binmode $fh;
-    print {$fh} $self->_freeze($data);
+    print {$fh} $self->_freeze( +{ %{$data} } );
     return;
 }
 


### PR DESCRIPTION
This was assuming on `-convert_blessed_universally` from `JSON.pm`
which is a very bad practice.

This was fixed in the newly released Dancer::Session::JSON and
should be fixed in Dancer2::Session::JSON.

Tests seem to pass. Please to merge + release kxthxbye. :)
